### PR TITLE
feat(linkMans): work for non-global installs

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,9 +115,11 @@ function linkBin (from, to, opts) {
 }
 
 function linkMans (pkg, folder, parent, gtop, opts) {
-  if (!pkg.man || !gtop || process.platform === 'win32') return
+  if (!pkg.man || process.platform === 'win32' ||
+      (!gtop && path.basename(parent) !== 'node_modules')) return
 
-  var manRoot = path.resolve(opts.prefix, 'share', 'man')
+  var manRoot = gtop ? path.resolve(opts.prefix, 'share', 'man')
+                     : path.resolve(parent, '.man')
   opts.log.verbose('linkMans', 'man files are', pkg.man, 'in', manRoot)
 
   // make sure that the mans are unique.


### PR DESCRIPTION
Hello! :)

I filed this support ticket thingy https://npm.community/t/npm-install-man-page-location/1512/2 but decided to go in myself and figure it out (it took a lot of grep to find the right place ha).

Anyways, the basic idea here is that man pages should be linked even for non-global installs into `.man` like bin files are linked to `.bin`.

I don't know how to write tests specifically for this functionality, as I don't see tests for the `.bin` linking functionality.  To test this manually however, I modified this file in a fresh checkout of npm and installed a module I know has man pages manually to a directory.

```
$ mkdir ~/temp
$ cd ~/temp
$ ~/dev/cli/bin/npm-cli.js install --global-style manta
...
(install works as expected)
$ ls -lha node_modules/
total 4.5K
drwxr-xr-x 5 dave chef  5 Aug 20 20:39 ./
drwxr-xr-x 3 dave chef  4 Aug 20 20:39 ../
drwxr-xr-x 2 dave chef 19 Aug 20 20:39 .bin/
drwxr-xr-x 3 dave chef  3 Aug 20 20:39 .man/
drwxr-xr-x 8 dave chef 14 Aug 20 20:39 manta/
$ ls -lh node_modules/.man/
total 1.5K
drwxr-xr-x 2 dave chef 18 Aug 20 20:39 man1/
$ ls -lh node_modules/.man/man1/
total 8.0K
lrwxrwxrwx 1 dave chef 30 Aug 20 20:39 mchattr.1 -> ../../manta/man/man1/mchattr.1
lrwxrwxrwx 1 dave chef 29 Aug 20 20:39 mchmod.1 -> ../../manta/man/man1/mchmod.1
lrwxrwxrwx 1 dave chef 28 Aug 20 20:39 mfind.1 -> ../../manta/man/man1/mfind.1
lrwxrwxrwx 1 dave chef 27 Aug 20 20:39 mget.1 -> ../../manta/man/man1/mget.1
lrwxrwxrwx 1 dave chef 28 Aug 20 20:39 minfo.1 -> ../../manta/man/man1/minfo.1
lrwxrwxrwx 1 dave chef 27 Aug 20 20:39 mjob.1 -> ../../manta/man/man1/mjob.1
lrwxrwxrwx 1 dave chef 26 Aug 20 20:39 mln.1 -> ../../manta/man/man1/mln.1
lrwxrwxrwx 1 dave chef 29 Aug 20 20:39 mlogin.1 -> ../../manta/man/man1/mlogin.1
lrwxrwxrwx 1 dave chef 26 Aug 20 20:39 mls.1 -> ../../manta/man/man1/mls.1
lrwxrwxrwx 1 dave chef 29 Aug 20 20:39 mmkdir.1 -> ../../manta/man/man1/mmkdir.1
lrwxrwxrwx 1 dave chef 27 Aug 20 20:39 mmpu.1 -> ../../manta/man/man1/mmpu.1
lrwxrwxrwx 1 dave chef 27 Aug 20 20:39 mput.1 -> ../../manta/man/man1/mput.1
lrwxrwxrwx 1 dave chef 26 Aug 20 20:39 mrm.1 -> ../../manta/man/man1/mrm.1
lrwxrwxrwx 1 dave chef 29 Aug 20 20:39 mrmdir.1 -> ../../manta/man/man1/mrmdir.1
lrwxrwxrwx 1 dave chef 28 Aug 20 20:39 msign.1 -> ../../manta/man/man1/msign.1
lrwxrwxrwx 1 dave chef 29 Aug 20 20:39 muntar.1 -> ../../manta/man/man1/muntar.1
```

And finally

```
$ export MANPATH=$MANPATH:$PWD/node_modules/.man
$ man mchattr
(works!)
```

I'm happy to make whatever changes need to be made to get this functionality accepted, as well as try my hand at writing tests/documentation for it... please just point me in the right direction :)

Thanks!
dave