### PR TITLE
feat(hooks): Add support for linking hook scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ binaries and man pages for Javascript packages
 
 * Links bin files listed under the `bin` property of pkg to the node_modules/.bin
 directory of the installing environment.
+* Links bin files listed under the `hooks` property of pkg to the node_modules/.hooks
+directory of the installing environment.
 * Links man files listed under the `man` property of pkg to the share/man directory
 of the provided optional directory prefix.
 

--- a/test/index.js
+++ b/test/index.js
@@ -24,12 +24,18 @@ const pkg = {
     hashbang: './hashbang.js',
     nohashbang: './nohashbang.js',
     'hashbang-nocr': './hashbang-nocr.js'
+  },
+  hooks: {
+    hashbang: './hashbang.js',
+    nohashbang: './nohashbang.js',
+    'hashbang-nocr': './hashbang-nocr.js'
   }
 }
 
 const folder = path.join(__dirname, '..', 'fixtures', 'convert-windows-newlines')
 const nodeModulesFolder = path.join(folder, 'node_modules')
 const pkgFolder = path.join(nodeModulesFolder, pkg.name)
+console.log({pkgFolder})
 
 test('converts windows newlines correctly', function (t) {
   cleanup()
@@ -66,6 +72,18 @@ test('converts windows newlines correctly', function (t) {
     )
     t.ok(
       existsSync(path.resolve(folder, 'node_modules/.bin/nohashbang')),
+      'nohashbang installed'
+    )
+    t.ok(
+      existsSync(path.resolve(folder, 'node_modules/.hooks/hashbang')),
+      'hashbang installed'
+    )
+    t.ok(
+      existsSync(path.resolve(folder, 'node_modules/.hooks/hashbang-nocr')),
+      'hashbang installed'
+    )
+    t.ok(
+      existsSync(path.resolve(folder, 'node_modules/.hooks/nohashbang')),
       'nohashbang installed'
     )
     const content = fs.readFileSync(


### PR DESCRIPTION
Fixes: #4

This implements support for a "hooks" field in package.json for linking to [hook scripts](https://docs.npmjs.com/misc/scripts#hook-scripts) from node_modules/.hooks/

It follows the same pattern as for .bin scripts, with the exception that it's hook scripts are not linked when installing global packages.