### PR TITLE
Move mkdirp to devDependencies and add missing mkdirp-infer-owner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -350,9 +350,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.3.tgz",
-      "integrity": "sha512-i70fVHhmV3DtTl6nqvZOnIjbY0Pe4kAUjwHj8z0zAdgBtYrJyYwLKCCuRBQ5ppkyL0AkN7HKRnETdmdp1zqNXw=="
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
     },
     "cliui": {
       "version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -22,13 +22,14 @@
   "license": "ISC",
   "dependencies": {
     "cmd-shim": "^4.0.1",
-    "mkdirp": "^1.0.3",
+    "mkdirp-infer-owner": "^1.0.2",
     "npm-normalize-package-bin": "^1.0.0",
     "read-cmd-shim": "^2.0.0",
     "rimraf": "^3.0.0",
     "write-file-atomic": "^2.3.0"
   },
   "devDependencies": {
+    "mkdirp": "^1.0.3",
     "require-inject": "^1.4.4",
     "tap": "^14.10.6"
   },


### PR DESCRIPTION
# What / Why
mkdirp package is only used in the test (so it should be included as a devDependencies). However mkdirp-infer-owner is used as dependencies in the code but does not appear in the  dep list.

This pull-request fix the problem.

Best Regards,
Thomas