### PR TITLE
Fix ENOENT caused by chmod of nonexistent bin

### DIFF
--- a/lib/link-gently.js
+++ b/lib/link-gently.js
@@ -63,7 +63,7 @@ const linkGently = async ({path, to, from, absFrom, force}) => {
   })
   .then(skipOrClobber => {
     if (skipOrClobber === SKIP)
-      return true
+      return false
     return symlink(from, to, 'file').catch(er => {
       if (skipOrClobber === CLOBBER || force)
         return rm(to).then(() => symlink(from, to, 'file'))


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->
This PR changes the `linkGently` method to return false when a bin doesn't exist so that the call to `fixBin` is bypassed:
https://github.com/npm/bin-links/blob/47e3e535d595efb9cdd110f5e6936b68f34c4f60/lib/link-bin.js#L6-L7

This prevents `fixBin` being called for a nonexistent bin, which would result in a chmod failure and an ENOENT error.

This fix handles the first SKIP case where a symlink does not exist:
https://github.com/npm/bin-links/blob/47e3e535d595efb9cdd110f5e6936b68f34c4f60/lib/link-gently.js#L42-L44

Let me know if a change is necessary to handle the second SKIP case where a symlink already exists. Should npm still try to call `fixBin` in this case?
https://github.com/npm/bin-links/blob/47e3e535d595efb9cdd110f5e6936b68f34c4f60/lib/link-gently.js#L52-L53

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
Fixes https://github.com/npm/cli/issues/2632