### PR TITLE
feat: fixBin accept exec mode as optional parameter

### DIFF
--- a/lib/fix-bin.js
+++ b/lib/fix-bin.js
@@ -37,7 +37,7 @@ const dos2Unix = file =>
   readFile(file, 'utf8').then(content =>
     writeFileAtomic(file, content.replace(/^(#![^\n]+)\r\n/, '$1\n')))
 
-const fixBin = file => chmod(file, execMode)
+const fixBin = (file, mode = execMode) => chmod(file, mode)
   .then(() => isWindowsHashbangFile(file))
   .then(isWHB => isWHB ? dos2Unix(file) : null)
 

--- a/test/fix-bin.js
+++ b/test/fix-bin.js
@@ -74,3 +74,27 @@ t.test('failure to close is ignored', t => {
       `#!/usr/bin/env node\nconsole.log('hello')\r\n`, 'fixed \\r on hashbang line (ignored failed close)')
   })
 })
+
+t.test('custom exec mode', t => {
+  const dir = t.testdir({
+    goodhb: `#!/usr/bin/env node\nconsole.log('hello')\r\n`,
+  })
+  chmodSync(`${dir}/goodhb`, 0o644)
+  return fixBin(`${dir}/goodhb`, 0o755).then(() => {
+    t.equal((statSync(`${dir}/goodhb`).mode & 0o755), 0o755 & (~umask), 'has exec perms')
+    t.equal(readFileSync(`${dir}/goodhb`, 'utf8'),
+      `#!/usr/bin/env node\nconsole.log('hello')\r\n`, 'fixed \\r on hashbang line')
+  })
+})
+
+t.test('custom exec mode in windows', t => {
+  const dir = t.testdir({
+    goodhb: `#!/usr/bin/env node\r\nconsole.log('hello')\r\n`,
+  })
+  chmodSync(`${dir}/goodhb`, 0o644)
+  return fixBin(`${dir}/goodhb`, 0o755).then(() => {
+    t.equal((statSync(`${dir}/goodhb`).mode & 0o755), 0o755 & (~umask), 'has exec perms')
+    t.equal(readFileSync(`${dir}/goodhb`, 'utf8'),
+      `#!/usr/bin/env node\nconsole.log('hello')\r\n`, 'fixed \\r on hashbang line')
+  })
+})


### PR DESCRIPTION
<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->

There are some bin js file is using CRLF, and they cannot work with yarn/npminstall, but they can work with npm, due to `fixBin` would try to fix.

So if this package exports `isWindowsHashbangFile` and `dos2Unix`, we can pr to yarn/npminstall to reuse the logic removing windows line-endings on the hashbang line.

And about not just using the `fixBin` directly, because  `yarn/npminstall/pnpm` doesnot set the same chmod here, they set 0o755, but bin-links set 0o777.

* https://github.com/yarnpkg/yarn/blob/ba0a33b7dc513d262bce505d9446d18a173a839c/src/package-linker.js#L44
* https://github.com/vagusX/npminstall/blob/43fb55a2bf55a8083eef40b6a53a893198185aee/lib/bin.js#L42
* https://github.com/pnpm/pnpm/blob/58edad730758df622fcf5a15abc1af4a5a0ff9a0/packages/link-bins/src/index.ts#L200

## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->

* https://github.com/yarnpkg/yarn/issues/7173
* https://github.com/yarnpkg/yarn/issues/5480

Some issues from those packages:
* https://github.com/docsifyjs/docsify-cli/issues/78#issuecomment-567095875
* https://github.com/preactjs/preact-cli/issues/1431
* https://github.com/facebook/jscodeshift/issues/424#issuecomment-832648530
