### PR TITLE
fix: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/link-mans.js
+++ b/lib/link-mans.js
@@ -11,7 +11,7 @@ const linkMans = ({ path, pkg, top, force }) => {
   // break any links to c:\\blah or /foo/blah or ../blah
   // and filter out duplicates
   const set = [...new Set(pkg.man.map(man =>
-    man ? join('/', man).replace(/\\|:/g, '/').substr(1) : null)
+    man ? join('/', man).replace(/\\|:/g, '/').slice(1) : null)
     .filter(man => typeof man === 'string'))]
 
   return Promise.all(set.map(man => {


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.