### PR TITLE
fix: don’t try to chmod unlinked files

### DIFF
--- a/lib/link-gently.js
+++ b/lib/link-gently.js
@@ -28,7 +28,7 @@ const CLOBBER = Symbol('clobber - ours or in forceful mode')
 
 const linkGently = async ({ path, to, from, absFrom, force }) => {
   if (seen.has(to)) {
-    return true
+    return false
   }
   seen.add(to)
 

--- a/test/link-gently.js
+++ b/test/link-gently.js
@@ -109,7 +109,7 @@ t.test('racey race', async t => {
     existingLink: t.fixture('symlink', './pkg/hello.js'),
     existingFile: 'hello',
   })
-  await Promise.all([
+  const multipleLinked = await Promise.all([
     mockedLinkGently({
       path: `${dir}/pkg`,
       from: `./pkg/hello.js`,
@@ -126,6 +126,8 @@ t.test('racey race', async t => {
     }),
     new Promise((res) => fs.symlink(__filename, `${dir}/racecar`, 'file', res)),
   ])
+  t.ok(multipleLinked[0] || multipleLinked[1], 'should link one path succesfully')
+  t.notSame(multipleLinked[0], multipleLinked[1], 'should fail to link the other path')
   const target = fs.readlinkSync(`${dir}/racecar`)
   t.match(target, /^\.\/(other)?pkg\/hello\.js$/, 'should link to one of them')
 })


### PR DESCRIPTION
`linkGently` would return true if a link target had been visited before. `linkBin` would then chmod the link `to`, regardless of whether this file exists. This causes `npm install` to fail if multiple packages link to a non-existent bin with the same name.

By returning false in `linkGently`, `linkBin` no skips the chmod on the non-existent file.


## References

Fixes npm/cli#4597