### PR TITLE
feat: set manTarget to null on CI

### DIFF
--- a/lib/man-target.js
+++ b/lib/man-target.js
@@ -1,6 +1,7 @@
+const ciInfo = require('ci-info')
 const isWindows = require('./is-windows.js')
 const getPrefix = require('./get-prefix.js')
 const { dirname } = require('path')
 
-module.exports = ({ top, path }) => !top || isWindows ? null
+module.exports = ({ top, path }) => !top || isWindows || ciInfo.isCI ? null
   : dirname(getPrefix(path)) + '/share/man'

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   ],
   "license": "ISC",
   "dependencies": {
+    "ci-info": "^4.0.0",
     "cmd-shim": "^6.0.0",
     "npm-normalize-package-bin": "^3.0.0",
     "read-cmd-shim": "^4.0.0",

--- a/test/get-paths.js
+++ b/test/get-paths.js
@@ -49,6 +49,7 @@ for (const isWindows of [true, false]) {
             const getPaths = requireInject('../lib/get-paths.js', {
               path,
               '../lib/is-windows.js': isWindows,
+              'ci-info': { isCI: false },
             })
 
             t.plan(3)

--- a/test/link-mans.js
+++ b/test/link-mans.js
@@ -3,6 +3,7 @@ const t = require('tap')
 const requireInject = require('require-inject')
 const linkMans = requireInject('../lib/link-mans.js', {
   '../lib/link-gently.js': ({ from, to }) => Promise.resolve(`LINK ${from} ${to}`),
+  'ci-info': { isCI: false },
 })
 
 t.test('not top/global', t => linkMans({

--- a/test/man-target.js
+++ b/test/man-target.js
@@ -6,6 +6,7 @@ for (const isWindows of [true, false]) {
     const manTarget = requireInject('../lib/man-target.js', {
       '../lib/is-windows.js': isWindows,
       path: require('path')[isWindows ? 'win32' : 'posix'],
+      'ci-info': { isCI: false },
     })
 
     t.matchSnapshot(manTarget({


### PR DESCRIPTION
We got an issue, when npm failed to install a global pkg with attached man pages on CI:

https://github.com/google/zx/pull/806#issuecomment-2118310411
```
Run npm install -g zx
npm ERR! code EACCES
npm ERR! syscall symlink
npm ERR! path ../../../lib/node_modules/zx/man/zx.1
npm ERR! dest /usr/local/share/man/man1/zx.1
npm ERR! errno -13
npm ERR! Error: EACCES: permission denied, symlink '../../../lib/node_modules/zx/man/zx.1' -> '/usr/local/share/man/man1/zx.1'
npm ERR!  [Error: EACCES: permission denied, symlink '../../../lib/node_modules/zx/man/zx.1' -> '/usr/local/share/man/man1/zx.1'] {
npm ERR!   errno: -13,
npm ERR!   code: 'EACCES',
npm ERR!   syscall: 'symlink',
npm ERR!   path: '../../../lib/node_modules/zx/man/zx.1',
npm ERR!   dest: '/usr/local/share/man/man1/zx.1'
npm ERR! }
```
This is partly a GHA problem. But is there any practical sense in man pages on CI? Let's just turn off.