### PR TITLE
chore: bump @npmcli/template-oss from 4.30.0 to 5.1.0 and apply templ…

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # This file is automatically added by @npmcli/template-oss. Do not edit.
 
-* @npm/cli-team
+* @npm/cli-team @npm/cli-triage

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -21,17 +21,17 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Git User
         run: |
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund --package-lock
       - name: Run Production Audit

--- a/.github/workflows/ci-release.yml
+++ b/.github/workflows/ci-release.yml
@@ -32,7 +32,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Git User
@@ -48,11 +48,11 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ inputs.check-sha }}
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -84,26 +84,32 @@ jobs:
             os: macos-15-intel
             shell: bash
         node-version:
-          - 20.17.0
-          - 20.x
-          - 22.9.0
+          - 22.22.2
           - 22.x
+          - 24.15.0
+          - 24.x
+          - 26.0.0
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.17.0
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.x
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.9.0
+            node-version: 22.22.2
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.15.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.0.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.ref }}
       - name: Setup Git User
@@ -119,7 +125,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           sha: ${{ inputs.check-sha }}
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,17 +26,17 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Git User
         run: |
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Lint
@@ -61,32 +61,38 @@ jobs:
             os: macos-15-intel
             shell: bash
         node-version:
-          - 20.17.0
-          - 20.x
-          - 22.9.0
+          - 22.22.2
           - 22.x
+          - 24.15.0
+          - 24.x
+          - 26.0.0
+          - 26.x
         exclude:
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.17.0
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 20.x
-          - platform: { name: macOS, os: macos-15-intel, shell: bash }
-            node-version: 22.9.0
+            node-version: 22.22.2
           - platform: { name: macOS, os: macos-15-intel, shell: bash }
             node-version: 22.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.15.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 24.x
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.0.0
+          - platform: { name: macOS, os: macos-15-intel, shell: bash }
+            node-version: 26.x
     runs-on: ${{ matrix.platform.os }}
     defaults:
       run:
         shell: ${{ matrix.platform.shell }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Git User
         run: |
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Git User
         run: |
           git config --global user.email "npm-cli+bot@github.com"

--- a/.github/workflows/post-dependabot.yml
+++ b/.github/workflows/post-dependabot.yml
@@ -17,7 +17,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.ref }}
       - name: Setup Git User
@@ -25,11 +25,11 @@ jobs:
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Fetch Dependabot Metadata

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -23,7 +23,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Setup Git User
@@ -31,11 +31,11 @@ jobs:
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Run Commitlint on Commits

--- a/.github/workflows/release-integration.yml
+++ b/.github/workflows/release-integration.yml
@@ -34,7 +34,7 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ fromJSON(inputs.releases)[0].tagName }}
       - name: Setup Git User
@@ -42,11 +42,11 @@ jobs:
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Set npm authToken

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,17 +31,17 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Git User
         run: |
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Release Please
@@ -104,7 +104,7 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ needs.release.outputs.pr-branch }}
@@ -113,11 +113,11 @@ jobs:
           git config --global user.email "npm-cli+bot@github.com"
           git config --global user.name "npm CLI robot"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         id: node
         with:
-          node-version: 22.x
-          check-latest: contains('22.x', '.x')
+          node-version: 26.x
+          check-latest: contains('26.x', '.x')
       - name: Install Dependencies
         run: npm i --ignore-scripts --no-audit --no-fund
       - name: Create Release Manager Checklist Text

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@npmcli/eslint-config": "^6.0.0",
-    "@npmcli/template-oss": "4.30.0",
+    "@npmcli/template-oss": "5.1.0",
     "require-inject": "^1.4.4",
     "tap": "^16.0.1"
   },
@@ -49,13 +49,13 @@
     "lib/"
   ],
   "engines": {
-    "node": "^20.17.0 || >=22.9.0"
+    "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
   },
   "author": "GitHub Inc.",
   "templateOSS": {
     "//@npmcli/template-oss": "This file is partially managed by @npmcli/template-oss. Edits may be overwritten.",
     "windowsCI": false,
-    "version": "4.30.0",
+    "version": "5.1.0",
     "publish": true,
     "updateNpm": false
   }


### PR DESCRIPTION
…ate changes

- Update @npmcli/template-oss to 5.1.0
- Update Node.js engine requirement to ^22.22.2 || ^24.15.0 || >=26.0.0
- Drop Node 20 support per template-oss 5.x requirements
- Regenerate CI workflows for Node 22+, 24+, 26+
- Update all template-managed files via template-oss-apply

<!-- What / Why -->
<!-- Describe the request in detail. What it does and why it's being changed. -->


## References
<!-- Examples:
  Related to #0
  Depends on #0
  Blocked by #0
  Fixes #0
  Closes #0
-->
